### PR TITLE
docs: add Iconify sizing option and changelog

### DIFF
--- a/docs/developer-guide/form-schema.md
+++ b/docs/developer-guide/form-schema.md
@@ -645,6 +645,10 @@ menuSelect 基于 select，并兼容 select 的[参数](#select-params)。
   - `name`：Iconify 的图标名称，需要在使用的地方自行加载图标
 - `value-only`：是否仅返回图标数据，默认为 `false`
 - `popper-placement`：图标选择弹窗的打开位置，默认为 `auto`，可以为：`auto`、`auto-end`、`auto-start`、`bottom`、`bottom-end`、`bottom-start`、`left`、`left-end`、`left-start`、`right`、`right-end`、`right-start`、`top`、`top-end`、`top-start`
+- `sizing`：图标尺寸配置对象，包含以下属性：
+  - `enabled`：是否显示图标尺寸配置，默认为 `false`
+  - `default`：默认尺寸，默认为 `24`
+  - `presets`：预设尺寸，字符串数组类型
 
 #### 值类型
 

--- a/docs/developer-guide/plugin/api-changelog.md
+++ b/docs/developer-guide/plugin/api-changelog.md
@@ -3,6 +3,12 @@ title: API 变更日志
 description: 记录每一个版本的插件 API 变更记录，方便开发者适配
 ---
 
+## 2.23.0
+
+### 表单定义 > Iconify 表单类型新增 `sizing` 参数
+
+在 2.23.0 中，Iconify 表单类型默认不再显示图标大小选项，如果需要让用户设置图标大小，可以配置 `sizing` 参数，详细文档可查阅：[表单定义#Iconify](../../developer-guide/form-schema.md#iconify)
+
 ## 2.22.8
 
 ### 表单定义 > 新增 `toggle` 组件

--- a/docs/developer-guide/theme/api-changelog.md
+++ b/docs/developer-guide/theme/api-changelog.md
@@ -3,6 +3,12 @@ title: API 变更日志
 description: 记录每一个版本的主题 API 变更记录，方便开发者适配
 ---
 
+## 2.23.0
+
+### 表单定义 > Iconify 表单类型新增 `sizing` 参数
+
+在 2.23.0 中，Iconify 表单类型默认不再显示图标大小选项，如果需要让用户设置图标大小，可以配置 `sizing` 参数，详细文档可查阅：[表单定义#Iconify](../../developer-guide/form-schema.md#iconify)
+
 ## 2.22.8
 
 ### 表单定义 > 新增 `toggle` 表单类型


### PR DESCRIPTION
Add documentation for Iconify's new `sizing` form option in form-schema (properties: `enabled` (default false), `default` (default 24), and `presets` (string array)). Also add 2.23.0 entries to plugin and theme API changelogs noting the new `sizing` parameter and that icon size control is hidden by default; include link to the form-schema Iconify section.

See https://github.com/halo-dev/halo/pull/8346

```release-note
None
```