### PR TITLE
docs: add postFinder random API documentation

### DIFF
--- a/docs/developer-guide/theme/api-changelog.md
+++ b/docs/developer-guide/theme/api-changelog.md
@@ -3,6 +3,12 @@ title: API 变更日志
 description: 记录每一个版本的主题 API 变更记录，方便开发者适配
 ---
 
+## 2.24.1
+
+### 文章 Finder API > 新增 `random(maxSize)` 方法
+
+在 2.24.1 中，我们为文章 Finder API 新增了 `random(maxSize)` 方法，用于随机获取文章列表。详细文档可查阅：[文章 Finder API#random](../../developer-guide/theme/finder-apis/post.md#randommaxsize)。
+
 ## 2.23.0
 
 ### 表单定义 > Iconify 表单类型新增 `sizing` 参数

--- a/docs/developer-guide/theme/finder-apis/post.md
+++ b/docs/developer-guide/theme/finder-apis/post.md
@@ -131,6 +131,34 @@ List\<[#ListedPostVo](#listedpostvo)\>
 </ul>
 ```
 
+## random(maxSize)
+
+```js
+postFinder.random(maxSize);
+```
+
+### 描述
+
+随机获取文章列表。
+
+### 参数
+
+1. `maxSize:int` - 获取文章的最大数量，取值范围为 1 到 100。
+
+### 返回值
+
+List\<[#ListedPostVo](#listedpostvo)\>
+
+### 示例
+
+```html
+<ul th:with="posts = ${postFinder.random(10)}">
+  <li th:each="post : ${posts}">
+    <a th:href="@{${post.status.permalink}}" th:text="${post.spec.title}"></a>
+  </li>
+</ul>
+```
+
 ## `list({...})`
 
 ```js

--- a/versioned_docs/version-2.24/developer-guide/theme/api-changelog.md
+++ b/versioned_docs/version-2.24/developer-guide/theme/api-changelog.md
@@ -3,6 +3,12 @@ title: API 变更日志
 description: 记录每一个版本的主题 API 变更记录，方便开发者适配
 ---
 
+## 2.24.1
+
+### 文章 Finder API > 新增 `random(maxSize)` 方法
+
+在 2.24.1 中，我们为文章 Finder API 新增了 `random(maxSize)` 方法，用于随机获取文章列表。详细文档可查阅：[文章 Finder API#random](../../developer-guide/theme/finder-apis/post.md#randommaxsize)。
+
 ## 2.23.0
 
 ### 表单定义 > Iconify 表单类型新增 `sizing` 参数

--- a/versioned_docs/version-2.24/developer-guide/theme/finder-apis/post.md
+++ b/versioned_docs/version-2.24/developer-guide/theme/finder-apis/post.md
@@ -131,6 +131,34 @@ List\<[#ListedPostVo](#listedpostvo)\>
 </ul>
 ```
 
+## random(maxSize)
+
+```js
+postFinder.random(maxSize);
+```
+
+### 描述
+
+随机获取文章列表。
+
+### 参数
+
+1. `maxSize:int` - 获取文章的最大数量，取值范围为 1 到 100。
+
+### 返回值
+
+List\<[#ListedPostVo](#listedpostvo)\>
+
+### 示例
+
+```html
+<ul th:with="posts = ${postFinder.random(10)}">
+  <li th:each="post : ${posts}">
+    <a th:href="@{${post.status.permalink}}" th:text="${post.spec.title}"></a>
+  </li>
+</ul>
+```
+
 ## `list({...})`
 
 ```js


### PR DESCRIPTION
## Summary
- Add documentation for postFinder.random(maxSize)
- Document the maxSize range and return type
- Add a Thymeleaf usage example for the latest and 2.24 docs

## Tests
- pnpm lint

Closes #581

```release-note
None
```