### PR TITLE
docs: document site version global variable

### DIFF
--- a/docs/developer-guide/theme/global-variables.md
+++ b/docs/developer-guide/theme/global-variables.md
@@ -32,6 +32,12 @@ Halo 目前为模板引擎在全局提供了一些变量，本文档将列出已
 <img th:src="${site.logo}" alt="Logo" />
 ```
 
+显示当前 Halo 版本：
+
+```html
+<span th:text="${site.version}"></span>
+```
+
 ## theme
 
 ### 描述

--- a/docs/developer-guide/theme/vo/_SiteSettingVo.md
+++ b/docs/developer-guide/theme/vo/_SiteSettingVo.md
@@ -3,14 +3,17 @@
   "title": "string",                      // 站点标题
   "subtitle": "string",                   // 站点副标题
   "url": "string",                        // 站点的外部访问链接
+  "version": "string",                    // 当前 Halo 版本
   "logo": "string",                       // Logo 地址
   "favicon": "string",                    // Favicon 地址
+  "language": "string",                   // 站点语言
   "allowRegistration": false,             // 是否允许注册
   "post": {                               // 文章相关设置
     "postPageSize": 10,                   // 首页默认分页大小
     "archivePageSize": 10,                // 归档页默认分页大小
     "categoryPageSize": 10,               // 分类归档页默认分页大小
-    "tagPageSize": 10                     // 标签归档页默认分页大小
+    "tagPageSize": 10,                    // 标签归档页默认分页大小
+    "authorPageSize": 10                  // 作者归档页默认分页大小
   },
   "seo": {                                // SEO 相关设置
     "blockSpiders": false,                // 禁止搜索引擎抓取

--- a/versioned_docs/version-2.20/developer-guide/theme/global-variables.md
+++ b/versioned_docs/version-2.20/developer-guide/theme/global-variables.md
@@ -32,6 +32,12 @@ Halo 目前为模板引擎在全局提供了一些变量，本文档将列出已
 <img th:src="${site.logo}" alt="Logo" />
 ```
 
+显示当前 Halo 版本：
+
+```html
+<span th:text="${site.version}"></span>
+```
+
 ## theme
 
 ### 描述

--- a/versioned_docs/version-2.20/developer-guide/theme/vo/_SiteSettingVo.md
+++ b/versioned_docs/version-2.20/developer-guide/theme/vo/_SiteSettingVo.md
@@ -3,6 +3,7 @@
   "title": "string",                      // 站点标题
   "subtitle": "string",                   // 站点副标题
   "url": "string",                        // 站点的外部访问链接
+  "version": "string",                    // 当前 Halo 版本
   "logo": "string",                       // Logo 地址
   "favicon": "string",                    // Favicon 地址
   "allowRegistration": false,             // 是否允许注册

--- a/versioned_docs/version-2.21/developer-guide/theme/global-variables.md
+++ b/versioned_docs/version-2.21/developer-guide/theme/global-variables.md
@@ -32,6 +32,12 @@ Halo 目前为模板引擎在全局提供了一些变量，本文档将列出已
 <img th:src="${site.logo}" alt="Logo" />
 ```
 
+显示当前 Halo 版本：
+
+```html
+<span th:text="${site.version}"></span>
+```
+
 ## theme
 
 ### 描述

--- a/versioned_docs/version-2.21/developer-guide/theme/vo/_SiteSettingVo.md
+++ b/versioned_docs/version-2.21/developer-guide/theme/vo/_SiteSettingVo.md
@@ -3,8 +3,10 @@
   "title": "string",                      // 站点标题
   "subtitle": "string",                   // 站点副标题
   "url": "string",                        // 站点的外部访问链接
+  "version": "string",                    // 当前 Halo 版本
   "logo": "string",                       // Logo 地址
   "favicon": "string",                    // Favicon 地址
+  "language": "string",                   // 站点语言
   "allowRegistration": false,             // 是否允许注册
   "post": {                               // 文章相关设置
     "postPageSize": 10,                   // 首页默认分页大小

--- a/versioned_docs/version-2.22/developer-guide/theme/global-variables.md
+++ b/versioned_docs/version-2.22/developer-guide/theme/global-variables.md
@@ -32,6 +32,12 @@ Halo 目前为模板引擎在全局提供了一些变量，本文档将列出已
 <img th:src="${site.logo}" alt="Logo" />
 ```
 
+显示当前 Halo 版本：
+
+```html
+<span th:text="${site.version}"></span>
+```
+
 ## theme
 
 ### 描述

--- a/versioned_docs/version-2.22/developer-guide/theme/vo/_SiteSettingVo.md
+++ b/versioned_docs/version-2.22/developer-guide/theme/vo/_SiteSettingVo.md
@@ -3,8 +3,10 @@
   "title": "string",                      // 站点标题
   "subtitle": "string",                   // 站点副标题
   "url": "string",                        // 站点的外部访问链接
+  "version": "string",                    // 当前 Halo 版本
   "logo": "string",                       // Logo 地址
   "favicon": "string",                    // Favicon 地址
+  "language": "string",                   // 站点语言
   "allowRegistration": false,             // 是否允许注册
   "post": {                               // 文章相关设置
     "postPageSize": 10,                   // 首页默认分页大小

--- a/versioned_docs/version-2.23/developer-guide/theme/global-variables.md
+++ b/versioned_docs/version-2.23/developer-guide/theme/global-variables.md
@@ -32,6 +32,12 @@ Halo 目前为模板引擎在全局提供了一些变量，本文档将列出已
 <img th:src="${site.logo}" alt="Logo" />
 ```
 
+显示当前 Halo 版本：
+
+```html
+<span th:text="${site.version}"></span>
+```
+
 ## theme
 
 ### 描述

--- a/versioned_docs/version-2.23/developer-guide/theme/vo/_SiteSettingVo.md
+++ b/versioned_docs/version-2.23/developer-guide/theme/vo/_SiteSettingVo.md
@@ -3,14 +3,17 @@
   "title": "string",                      // 站点标题
   "subtitle": "string",                   // 站点副标题
   "url": "string",                        // 站点的外部访问链接
+  "version": "string",                    // 当前 Halo 版本
   "logo": "string",                       // Logo 地址
   "favicon": "string",                    // Favicon 地址
+  "language": "string",                   // 站点语言
   "allowRegistration": false,             // 是否允许注册
   "post": {                               // 文章相关设置
     "postPageSize": 10,                   // 首页默认分页大小
     "archivePageSize": 10,                // 归档页默认分页大小
     "categoryPageSize": 10,               // 分类归档页默认分页大小
-    "tagPageSize": 10                     // 标签归档页默认分页大小
+    "tagPageSize": 10,                    // 标签归档页默认分页大小
+    "authorPageSize": 10                  // 作者归档页默认分页大小
   },
   "seo": {                                // SEO 相关设置
     "blockSpiders": false,                // 禁止搜索引擎抓取

--- a/versioned_docs/version-2.24/developer-guide/theme/global-variables.md
+++ b/versioned_docs/version-2.24/developer-guide/theme/global-variables.md
@@ -32,6 +32,12 @@ Halo 目前为模板引擎在全局提供了一些变量，本文档将列出已
 <img th:src="${site.logo}" alt="Logo" />
 ```
 
+显示当前 Halo 版本：
+
+```html
+<span th:text="${site.version}"></span>
+```
+
 ## theme
 
 ### 描述

--- a/versioned_docs/version-2.24/developer-guide/theme/vo/_SiteSettingVo.md
+++ b/versioned_docs/version-2.24/developer-guide/theme/vo/_SiteSettingVo.md
@@ -3,14 +3,17 @@
   "title": "string",                      // 站点标题
   "subtitle": "string",                   // 站点副标题
   "url": "string",                        // 站点的外部访问链接
+  "version": "string",                    // 当前 Halo 版本
   "logo": "string",                       // Logo 地址
   "favicon": "string",                    // Favicon 地址
+  "language": "string",                   // 站点语言
   "allowRegistration": false,             // 是否允许注册
   "post": {                               // 文章相关设置
     "postPageSize": 10,                   // 首页默认分页大小
     "archivePageSize": 10,                // 归档页默认分页大小
     "categoryPageSize": 10,               // 分类归档页默认分页大小
-    "tagPageSize": 10                     // 标签归档页默认分页大小
+    "tagPageSize": 10,                    // 标签归档页默认分页大小
+    "authorPageSize": 10                  // 作者归档页默认分页大小
   },
   "seo": {                                // SEO 相关设置
     "blockSpiders": false,                // 禁止搜索引擎抓取


### PR DESCRIPTION
## Summary
- Document site.version in the theme global variables page
- Update SiteSettingVo examples according to the actual Halo source structure
- Keep versioned docs aligned with fields available in each Halo version

## Source checks
- SiteSettingVo includes version in Halo 2.20 and later
- SiteSettingVariablesAcquirer populates site.version from SystemVersionSupplier

## Tests
- pnpm lint
- pnpm build

Closes #582

```release-note
None
```