### PR TITLE
Add robots.txt and exclude next from sitemap

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,8 +79,9 @@ const config = {
         },
         sitemap: {
           changefreq: "weekly",
-          priority: 0.5,
-          ignorePatterns: ["/2.18/**", "/2.19/**", "/2.20/**", "/2.21/**", "/2.22/**", "/2.23/**"],
+          priority: null,
+          changefreq: null,
+          ignorePatterns: ["/next/**", "/2.18/**", "/2.19/**", "/2.20/**", "/2.21/**", "/2.22/**", "/2.23/**"],
         },
         googleAnalytics: {
           trackingID: "UA-110780416-7",

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,12 @@
+User-agent: *
+Allow: /
+Disallow: /next
+Disallow: /2.18
+Disallow: /2.19
+Disallow: /2.20
+Disallow: /2.21
+Disallow: /2.22
+Disallow: /2.23
+
+
+Sitemap: https://docs.halo.run/sitemap.xml


### PR DESCRIPTION
Create static/robots.txt to disallow crawling of the /next preview and old versioned docs and point to the sitemap. Update docusaurus.config.js sitemap settings: set priority and changefreq to null and add "/next/**" to ignorePatterns so preview content is excluded from the generated sitemap.

```release-note
None
```