### PR TITLE
Remove obsolete version field from docker-compose.yaml examples

### DIFF
--- a/docs/getting-started/install/docker-compose.md
+++ b/docs/getting-started/install/docker-compose.md
@@ -43,9 +43,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
 
    <Tabs queryString="current">
     <TabItem value="halo-postgresql" label="Halo + PostgreSQL（推荐）" default>
-         ```yaml {26-32,46} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,44} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo-pro:2.24
@@ -102,9 +100,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
          :::
     </TabItem>
     <TabItem value="halo-mysql" label="Halo + MySQL">
-         ```yaml {26-32,54} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,52} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo-pro:2.24
@@ -172,9 +168,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         不推荐在生产环境使用默认的 H2 数据库，这可能因为操作不当导致数据文件损坏。如果因为某些原因（如内存不足以运行独立数据库）必须要使用，建议按时[备份数据](../../user-guide/backup.md)。
         :::
 
-        ```yaml {22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo-pro:2.24
@@ -198,9 +192,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         ```
     </TabItem>
     <TabItem value="external-db" label="使用外部数据库">
-        ```yaml {7,15-22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {5,13-20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo-pro:2.24
@@ -325,9 +317,7 @@ reverse_proxy 127.0.0.1:8090
 3. 修改外部地址为你的域名
 4. 声明路由规则、开启 TLS
 
-```yaml {4-5,16,20,25-31}
-version: "3.8"
-
+```yaml {2-3,14,18,23-29}
 networks:
   traefik:
     external: true

--- a/versioned_docs/version-2.18/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.18/getting-started/install/docker-compose.md
@@ -47,9 +47,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
 
    <Tabs queryString="current">
     <TabItem value="halo-postgresql" label="Halo + PostgreSQL" default>
-         ```yaml {23-29,43} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {21-27,41} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo:2.18
@@ -103,9 +101,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
          :::
     </TabItem>
     <TabItem value="halo-mysql" label="Halo + MySQL">
-         ```yaml {23-29,51} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {21-27,49} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo:2.18
@@ -170,9 +166,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         不推荐在生产环境使用默认的 H2 数据库，这可能因为操作不当导致数据文件损坏。如果因为某些原因（如内存不足以运行独立数据库）必须要使用，建议按时[备份数据](../../user-guide/backup.md)。
         :::
 
-        ```yaml {19-24} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {17-22} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo:2.18
@@ -193,9 +187,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         ```
     </TabItem>
     <TabItem value="external-db" label="使用外部数据库">
-        ```yaml {7,12-20} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {5,10-18} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo:2.18
@@ -303,9 +295,7 @@ reverse_proxy 127.0.0.1:8090
 3. 修改外部地址为你的域名
 4. 声明路由规则、开启 TLS
 
-```yaml {4-5,16,20,25-31}
-version: "3.8"
-
+```yaml {2-3,14,18,23-29}
 networks:
   traefik:
     external: true

--- a/versioned_docs/version-2.19/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.19/getting-started/install/docker-compose.md
@@ -47,9 +47,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
 
    <Tabs queryString="current">
     <TabItem value="halo-postgresql" label="Halo + PostgreSQL" default>
-         ```yaml {23-29,43} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {21-27,41} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo:2.19
@@ -103,9 +101,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
          :::
     </TabItem>
     <TabItem value="halo-mysql" label="Halo + MySQL">
-         ```yaml {23-29,51} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {21-27,49} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo:2.19
@@ -170,9 +166,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         不推荐在生产环境使用默认的 H2 数据库，这可能因为操作不当导致数据文件损坏。如果因为某些原因（如内存不足以运行独立数据库）必须要使用，建议按时[备份数据](../../user-guide/backup.md)。
         :::
 
-        ```yaml {19-24} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {17-22} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo:2.19
@@ -193,9 +187,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         ```
     </TabItem>
     <TabItem value="external-db" label="使用外部数据库">
-        ```yaml {7,12-20} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {5,10-18} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo:2.19
@@ -303,9 +295,7 @@ reverse_proxy 127.0.0.1:8090
 3. 修改外部地址为你的域名
 4. 声明路由规则、开启 TLS
 
-```yaml {4-5,16,20,25-31}
-version: "3.8"
-
+```yaml {2-3,14,18,23-29}
 networks:
   traefik:
     external: true

--- a/versioned_docs/version-2.20/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.20/getting-started/install/docker-compose.md
@@ -47,9 +47,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
 
    <Tabs queryString="current">
     <TabItem value="halo-postgresql" label="Halo + PostgreSQL" default>
-         ```yaml {26-32,46} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,44} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo:2.20
@@ -106,9 +104,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
          :::
     </TabItem>
     <TabItem value="halo-mysql" label="Halo + MySQL">
-         ```yaml {26-32,54} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,52} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo:2.20
@@ -176,9 +172,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         不推荐在生产环境使用默认的 H2 数据库，这可能因为操作不当导致数据文件损坏。如果因为某些原因（如内存不足以运行独立数据库）必须要使用，建议按时[备份数据](../../user-guide/backup.md)。
         :::
 
-        ```yaml {22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo:2.20
@@ -202,9 +196,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         ```
     </TabItem>
     <TabItem value="external-db" label="使用外部数据库">
-        ```yaml {7,15-22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {5,13-20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo:2.20
@@ -327,9 +319,7 @@ reverse_proxy 127.0.0.1:8090
 3. 修改外部地址为你的域名
 4. 声明路由规则、开启 TLS
 
-```yaml {4-5,16,20,25-31}
-version: "3.8"
-
+```yaml {2-3,14,18,23-29}
 networks:
   traefik:
     external: true

--- a/versioned_docs/version-2.21/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.21/getting-started/install/docker-compose.md
@@ -47,9 +47,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
 
    <Tabs queryString="current">
     <TabItem value="halo-postgresql" label="Halo + PostgreSQL（推荐）" default>
-         ```yaml {26-32,46} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,44} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo:2.21
@@ -106,9 +104,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
          :::
     </TabItem>
     <TabItem value="halo-mysql" label="Halo + MySQL">
-         ```yaml {26-32,54} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,52} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo:2.21
@@ -176,9 +172,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         不推荐在生产环境使用默认的 H2 数据库，这可能因为操作不当导致数据文件损坏。如果因为某些原因（如内存不足以运行独立数据库）必须要使用，建议按时[备份数据](../../user-guide/backup.md)。
         :::
 
-        ```yaml {22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo:2.21
@@ -202,9 +196,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         ```
     </TabItem>
     <TabItem value="external-db" label="使用外部数据库">
-        ```yaml {7,15-22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {5,13-20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo:2.21
@@ -327,9 +319,7 @@ reverse_proxy 127.0.0.1:8090
 3. 修改外部地址为你的域名
 4. 声明路由规则、开启 TLS
 
-```yaml {4-5,16,20,25-31}
-version: "3.8"
-
+```yaml {2-3,14,18,23-29}
 networks:
   traefik:
     external: true

--- a/versioned_docs/version-2.22/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.22/getting-started/install/docker-compose.md
@@ -43,9 +43,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
 
    <Tabs queryString="current">
     <TabItem value="halo-postgresql" label="Halo + PostgreSQL（推荐）" default>
-         ```yaml {26-32,46} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,44} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo-pro:2.22
@@ -102,9 +100,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
          :::
     </TabItem>
     <TabItem value="halo-mysql" label="Halo + MySQL">
-         ```yaml {26-32,54} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,52} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo-pro:2.22
@@ -172,9 +168,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         不推荐在生产环境使用默认的 H2 数据库，这可能因为操作不当导致数据文件损坏。如果因为某些原因（如内存不足以运行独立数据库）必须要使用，建议按时[备份数据](../../user-guide/backup.md)。
         :::
 
-        ```yaml {22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo-pro:2.22
@@ -198,9 +192,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         ```
     </TabItem>
     <TabItem value="external-db" label="使用外部数据库">
-        ```yaml {7,15-22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {5,13-20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo-pro:2.22
@@ -325,9 +317,7 @@ reverse_proxy 127.0.0.1:8090
 3. 修改外部地址为你的域名
 4. 声明路由规则、开启 TLS
 
-```yaml {4-5,16,20,25-31}
-version: "3.8"
-
+```yaml {2-3,14,18,23-29}
 networks:
   traefik:
     external: true

--- a/versioned_docs/version-2.23/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.23/getting-started/install/docker-compose.md
@@ -43,9 +43,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
 
    <Tabs queryString="current">
     <TabItem value="halo-postgresql" label="Halo + PostgreSQL（推荐）" default>
-         ```yaml {26-32,46} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,44} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo-pro:2.23
@@ -102,9 +100,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
          :::
     </TabItem>
     <TabItem value="halo-mysql" label="Halo + MySQL">
-         ```yaml {26-32,54} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,52} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo-pro:2.23
@@ -172,9 +168,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         不推荐在生产环境使用默认的 H2 数据库，这可能因为操作不当导致数据文件损坏。如果因为某些原因（如内存不足以运行独立数据库）必须要使用，建议按时[备份数据](../../user-guide/backup.md)。
         :::
 
-        ```yaml {22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo-pro:2.23
@@ -198,9 +192,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         ```
     </TabItem>
     <TabItem value="external-db" label="使用外部数据库">
-        ```yaml {7,15-22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {5,13-20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo-pro:2.23
@@ -325,9 +317,7 @@ reverse_proxy 127.0.0.1:8090
 3. 修改外部地址为你的域名
 4. 声明路由规则、开启 TLS
 
-```yaml {4-5,16,20,25-31}
-version: "3.8"
-
+```yaml {2-3,14,18,23-29}
 networks:
   traefik:
     external: true

--- a/versioned_docs/version-2.24/getting-started/install/docker-compose.md
+++ b/versioned_docs/version-2.24/getting-started/install/docker-compose.md
@@ -43,9 +43,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
 
    <Tabs queryString="current">
     <TabItem value="halo-postgresql" label="Halo + PostgreSQL（推荐）" default>
-         ```yaml {26-32,46} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,44} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo-pro:2.24
@@ -102,9 +100,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
          :::
     </TabItem>
     <TabItem value="halo-mysql" label="Halo + MySQL">
-         ```yaml {26-32,54} title="~/halo/docker-compose.yaml"
-         version: "3"
-
+         ```yaml {24-30,52} title="~/halo/docker-compose.yaml"
          services:
            halo:
              image: registry.fit2cloud.com/halo/halo-pro:2.24
@@ -172,9 +168,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         不推荐在生产环境使用默认的 H2 数据库，这可能因为操作不当导致数据文件损坏。如果因为某些原因（如内存不足以运行独立数据库）必须要使用，建议按时[备份数据](../../user-guide/backup.md)。
         :::
 
-        ```yaml {22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo-pro:2.24
@@ -198,9 +192,7 @@ import DockerRegistryList from "./slots/_docker-registry-list.md"
         ```
     </TabItem>
     <TabItem value="external-db" label="使用外部数据库">
-        ```yaml {7,15-22} title="~/halo/docker-compose.yaml"
-        version: "3"
-
+        ```yaml {5,13-20} title="~/halo/docker-compose.yaml"
         services:
           halo:
             image: registry.fit2cloud.com/halo/halo-pro:2.24
@@ -325,9 +317,7 @@ reverse_proxy 127.0.0.1:8090
 3. 修改外部地址为你的域名
 4. 声明路由规则、开启 TLS
 
-```yaml {4-5,16,20,25-31}
-version: "3.8"
-
+```yaml {2-3,14,18,23-29}
 networks:
   traefik:
     external: true


### PR DESCRIPTION
### What this PR does

Removes the obsolete `version` field from all `docker-compose.yaml` examples in the documentation. 

### Why

Docker Compose 2.0+ ignores the `version` field and emits a warning:

```
WARN[0000] /path/to/docker-compose.yaml: version is obsolete
```

This can confuse users following the installation guide (see #505).

### Changes

- Removed `version: "3"` and `version: "3.8"` from all docker-compose.yaml code blocks
- Updated corresponding code-highlight line numbers to match the new content
- Affected files: current docs + versioned docs (2.18–2.24)

Fixes #505