### PR TITLE
docs: add dev-skills documentation for theme and plugin development

### DIFF
--- a/docs/developer-guide/plugin/prepare.md
+++ b/docs/developer-guide/plugin/prepare.md
@@ -15,3 +15,15 @@ description: 插件开发的准备工作
 - Git 是一个版本控制系统，用于跟踪代码的更改，您需要 Git 来下载示例插件并发布插件。
 
 同时需要先阅读 [Halo 架构概览](../core/framework.md) 以了解 Halo 的核心概念和技术栈。
+
+## AI 辅助开发
+
+Halo 官方为插件开发者提供了 Agent Skills，支持在 Cursor、Claude Code、Codex 等 AI 开发工具中使用，以获得 Halo 插件开发的深度上下文和辅助能力。
+
+- [halo-dev/dev-skills](https://github.com/halo-dev/dev-skills) - 包含 `halo-plugin-dev` Skill，涵盖插件目录结构、Java 后端开发、Vue 3 前端开发、RBAC 权限管理、DevTools 工作流、OpenAPI 客户端生成等内容。
+
+安装方式：
+
+```bash
+npx skills add halo-dev/dev-skills@halo-plugin-dev -g
+```

--- a/docs/developer-guide/theme/prepare.md
+++ b/docs/developer-guide/theme/prepare.md
@@ -75,6 +75,18 @@ spec:
 创建新的主题仓库并克隆到本地开发环境之后，需要确保主题文件夹名称和 `theme.yaml` 中的 `metadata.name` 字段一致，否则可能导致部分资源无法正常加载。
 :::
 
+## AI 辅助开发
+
+Halo 官方为主题开发者提供了 Agent Skills，支持在 Cursor、Claude Code、Codex 等 AI 开发工具中使用，以获得 Halo 主题开发的深度上下文和辅助能力。
+
+- [halo-dev/dev-skills](https://github.com/halo-dev/dev-skills) - 包含 `halo-theme-dev` Skill，涵盖主题目录结构、Thymeleaf 模板、Finder API、静态资源管理、主题设置表单等内容，并提供了最小主题和 Vite 主题的初始模板。
+
+安装方式：
+
+```bash
+npx skills add halo-dev/dev-skills@halo-theme-dev -g
+```
+
 ## 创建第一个页面模板
 
 Halo 使用 [Thymeleaf](https://www.thymeleaf.org/) 作为后端模板引擎，后缀为 `.html`，与单纯编写 HTML 一致。在 Halo 的主题中，主题的模板文件存放于 `templates` 目录下，例如 `~/halo2-dev/themes/theme-foo/templates`。为了此文档方便演示，我们先在 `templates` 创建一个首页的模板文件 `index.html`：

--- a/versioned_docs/version-2.24/developer-guide/plugin/prepare.md
+++ b/versioned_docs/version-2.24/developer-guide/plugin/prepare.md
@@ -15,3 +15,15 @@ description: 插件开发的准备工作
 - Git 是一个版本控制系统，用于跟踪代码的更改，您需要 Git 来下载示例插件并发布插件。
 
 同时需要先阅读 [Halo 架构概览](../core/framework.md) 以了解 Halo 的核心概念和技术栈。
+
+## AI 辅助开发
+
+Halo 官方为插件开发者提供了 Agent Skills，支持在 Cursor、Claude Code、Codex 等 AI 开发工具中使用，以获得 Halo 插件开发的深度上下文和辅助能力。
+
+- [halo-dev/dev-skills](https://github.com/halo-dev/dev-skills) - 包含 `halo-plugin-dev` Skill，涵盖插件目录结构、Java 后端开发、Vue 3 前端开发、RBAC 权限管理、DevTools 工作流、OpenAPI 客户端生成等内容。
+
+安装方式：
+
+```bash
+npx skills add halo-dev/dev-skills@halo-plugin-dev -g
+```

--- a/versioned_docs/version-2.24/developer-guide/theme/prepare.md
+++ b/versioned_docs/version-2.24/developer-guide/theme/prepare.md
@@ -75,6 +75,18 @@ spec:
 创建新的主题仓库并克隆到本地开发环境之后，需要确保主题文件夹名称和 `theme.yaml` 中的 `metadata.name` 字段一致，否则可能导致部分资源无法正常加载。
 :::
 
+## AI 辅助开发
+
+Halo 官方为主题开发者提供了 Agent Skills，支持在 Cursor、Claude Code、Codex 等 AI 开发工具中使用，以获得 Halo 主题开发的深度上下文和辅助能力。
+
+- [halo-dev/dev-skills](https://github.com/halo-dev/dev-skills) - 包含 `halo-theme-dev` Skill，涵盖主题目录结构、Thymeleaf 模板、Finder API、静态资源管理、主题设置表单等内容，并提供了最小主题和 Vite 主题的初始模板。
+
+安装方式：
+
+```bash
+npx skills add halo-dev/dev-skills@halo-theme-dev -g
+```
+
 ## 创建第一个页面模板
 
 Halo 使用 [Thymeleaf](https://www.thymeleaf.org/) 作为后端模板引擎，后缀为 `.html`，与单纯编写 HTML 一致。在 Halo 的主题中，主题的模板文件存放于 `templates` 目录下，例如 `~/halo2-dev/themes/theme-foo/templates`。为了此文档方便演示，我们先在 `templates` 创建一个首页的模板文件 `index.html`：


### PR DESCRIPTION
## Summary

Add AI-assisted development section to theme and plugin prepare guides, introducing the [halo-dev/dev-skills](https://github.com/halo-dev/dev-skills) repository for Cursor, Claude Code, and other AI agents.

## Changes

- `docs/developer-guide/theme/prepare.md`
- `docs/developer-guide/plugin/prepare.md`
- `versioned_docs/version-2.24/developer-guide/theme/prepare.md`
- `versioned_docs/version-2.24/developer-guide/plugin/prepare.md`

Each file now includes a new \"AI-assisted development\" section that:

1. Mentions the `halo-dev/dev-skills` repository
2. Describes the available skills (`halo-theme-dev` and `halo-plugin-dev`)
3. Provides the installation command via Skills CLI

```release-note
None
```