### PR TITLE
Use example package names in plugin documentation

### DIFF
--- a/docs/developer-guide/plugin/basics/structure.md
+++ b/docs/developer-guide/plugin/basics/structure.md
@@ -25,8 +25,8 @@ description: 了解插件项目的文件结构
 ├── src
 │   └── main
 │       ├── java
-│       │   └── run
-│       │       └── halo
+│       │   └── com
+│       │       └── example
 │       │           └── starter
 │       │               └── StarterPlugin.java
 │       └── resources
@@ -49,7 +49,7 @@ description: 了解插件项目的文件结构
 
 `src` 目录中存放的是后端代码，这部分遵循标准的 Java 项目结构。以下是各个文件和文件夹的说明：
 
-- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/run/halo/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
+- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/com/example/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
 - `plugin.yaml`：这是插件的描述文件，位于 `src/main/resources` 目录下。该文件是必须的，包含插件的基本信息，如插件名称、版本、作者、描述以及依赖等内容。
 - `resources/console`：该文件夹通常包含前端部分打包后生成的文件，包括 main.js（JavaScript 文件）和 style.css（样式表）。如果插件不包含前端部分，此目录可以忽略。
 

--- a/docs/developer-guide/plugin/basics/ui/build.md
+++ b/docs/developer-guide/plugin/basics/ui/build.md
@@ -288,7 +288,7 @@ export default definePlugin({
         id "run.halo.plugin.devtools" version "0.6.0"
     }
 
-    group 'run.halo.starter'
+    group 'com.example.starter'
 
     repositories {
         mavenCentral()
@@ -342,7 +342,7 @@ export default definePlugin({
         id "com.github.node-gradle.node" version "7.1.0"
     }
 
-    group 'run.halo.starter.ui'
+    group 'com.example.starter.ui'
 
     tasks.register('buildFrontend', PnpmTask) {
         group = 'build'

--- a/docs/developer-guide/plugin/examples/todolist.md
+++ b/docs/developer-guide/plugin/examples/todolist.md
@@ -18,7 +18,7 @@ description: 这个例子展示了如何开发 Todo List 插件
 首先创建一个 `class` 名为 `Todo` 并写入如下内容：
 
 ```java
-package run.halo.tutorial;
+package com.example.tutorial;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 

--- a/docs/developer-guide/plugin/interaction/shared-events.md
+++ b/docs/developer-guide/plugin/interaction/shared-events.md
@@ -124,7 +124,7 @@ public class CustomEventPublisher {
 
    ```groovy
    dependencies {
-     compileOnly "run.halo.example:plugin-a-api:1.0.0"
+     compileOnly "com.example.app:plugin-a-api:1.0.0"
    }
    ```
 

--- a/versioned_docs/version-2.20/developer-guide/plugin/basics/structure.md
+++ b/versioned_docs/version-2.20/developer-guide/plugin/basics/structure.md
@@ -25,8 +25,8 @@ description: 了解插件项目的文件结构
 ├── src
 │   └── main
 │       ├── java
-│       │   └── run
-│       │       └── halo
+│       │   └── com
+│       │       └── example
 │       │           └── starter
 │       │               └── StarterPlugin.java
 │       └── resources
@@ -49,7 +49,7 @@ description: 了解插件项目的文件结构
 
 `src` 目录中存放的是后端代码，这部分遵循标准的 Java 项目结构。以下是各个文件和文件夹的说明：
 
-- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/run/halo/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
+- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/com/example/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
 - `plugin.yaml`：这是插件的描述文件，位于 `src/main/resources` 目录下。该文件是必须的，包含插件的基本信息，如插件名称、版本、作者、描述以及依赖等内容。
 - `resources/console`：该文件夹通常包含前端部分打包后生成的文件，包括 main.js（JavaScript 文件）和 style.css（样式表）。如果插件不包含前端部分，此目录可以忽略。
 

--- a/versioned_docs/version-2.20/developer-guide/plugin/examples/todolist.md
+++ b/versioned_docs/version-2.20/developer-guide/plugin/examples/todolist.md
@@ -12,7 +12,7 @@ description: 这个例子展示了如何开发 Todo List 插件
 1. 修改 `build.gradle` 中的 `group` 为你自己的，如：
 
    ```groovy
-   group = 'run.halo.tutorial'
+   group = 'com.example.tutorial'
    ```
 
 2. 修改 `settings.gradle` 中的 `rootProject.name`
@@ -56,10 +56,10 @@ description: 这个例子展示了如何开发 Todo List 插件
 
 为了看到效果，首先我们需要让插件能最简单的运行起来。
 
-1. 在 `src/main/java` 下创建包，如 `run.halo.tutorial`，在创建一个类 `TodoListPlugin`，它继承自 `BasePlugin` 类内容如下：
+1. 在 `src/main/java` 下创建包，如 `com.example.tutorial`，在创建一个类 `TodoListPlugin`，它继承自 `BasePlugin` 类内容如下：
 
    ```java
-   package run.halo.tutorial;
+   package com.example.tutorial;
 
    import run.halo.app.plugin.PluginContext;
    import org.springframework.stereotype.Component;
@@ -113,7 +113,7 @@ description: 这个例子展示了如何开发 Todo List 插件
 首先创建一个 `class` 名为 `Todo` 并写入如下内容：
 
 ```java
-package run.halo.tutorial;
+package com.example.tutorial;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 

--- a/versioned_docs/version-2.20/developer-guide/plugin/interaction/shared-events.md
+++ b/versioned_docs/version-2.20/developer-guide/plugin/interaction/shared-events.md
@@ -119,7 +119,7 @@ public class CustomEventPublisher {
 
    ```groovy
    dependencies {
-     compileOnly "run.halo.example:plugin-a-api:1.0.0"
+     compileOnly "com.example.app:plugin-a-api:1.0.0"
    }
    ```
 

--- a/versioned_docs/version-2.21/developer-guide/plugin/basics/structure.md
+++ b/versioned_docs/version-2.21/developer-guide/plugin/basics/structure.md
@@ -25,8 +25,8 @@ description: 了解插件项目的文件结构
 ├── src
 │   └── main
 │       ├── java
-│       │   └── run
-│       │       └── halo
+│       │   └── com
+│       │       └── example
 │       │           └── starter
 │       │               └── StarterPlugin.java
 │       └── resources
@@ -49,7 +49,7 @@ description: 了解插件项目的文件结构
 
 `src` 目录中存放的是后端代码，这部分遵循标准的 Java 项目结构。以下是各个文件和文件夹的说明：
 
-- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/run/halo/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
+- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/com/example/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
 - `plugin.yaml`：这是插件的描述文件，位于 `src/main/resources` 目录下。该文件是必须的，包含插件的基本信息，如插件名称、版本、作者、描述以及依赖等内容。
 - `resources/console`：该文件夹通常包含前端部分打包后生成的文件，包括 main.js（JavaScript 文件）和 style.css（样式表）。如果插件不包含前端部分，此目录可以忽略。
 

--- a/versioned_docs/version-2.21/developer-guide/plugin/basics/ui/build.md
+++ b/versioned_docs/version-2.21/developer-guide/plugin/basics/ui/build.md
@@ -288,7 +288,7 @@ export default definePlugin({
         id "run.halo.plugin.devtools" version "0.6.0"
     }
 
-    group 'run.halo.starter'
+    group 'com.example.starter'
 
     repositories {
         mavenCentral()
@@ -342,7 +342,7 @@ export default definePlugin({
         id "com.github.node-gradle.node" version "7.1.0"
     }
 
-    group 'run.halo.starter.ui'
+    group 'com.example.starter.ui'
 
     tasks.register('buildFrontend', PnpmTask) {
         group = 'build'

--- a/versioned_docs/version-2.21/developer-guide/plugin/examples/todolist.md
+++ b/versioned_docs/version-2.21/developer-guide/plugin/examples/todolist.md
@@ -18,7 +18,7 @@ description: 这个例子展示了如何开发 Todo List 插件
 首先创建一个 `class` 名为 `Todo` 并写入如下内容：
 
 ```java
-package run.halo.tutorial;
+package com.example.tutorial;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 

--- a/versioned_docs/version-2.21/developer-guide/plugin/interaction/shared-events.md
+++ b/versioned_docs/version-2.21/developer-guide/plugin/interaction/shared-events.md
@@ -124,7 +124,7 @@ public class CustomEventPublisher {
 
    ```groovy
    dependencies {
-     compileOnly "run.halo.example:plugin-a-api:1.0.0"
+     compileOnly "com.example.app:plugin-a-api:1.0.0"
    }
    ```
 

--- a/versioned_docs/version-2.22/developer-guide/plugin/basics/structure.md
+++ b/versioned_docs/version-2.22/developer-guide/plugin/basics/structure.md
@@ -25,8 +25,8 @@ description: 了解插件项目的文件结构
 ├── src
 │   └── main
 │       ├── java
-│       │   └── run
-│       │       └── halo
+│       │   └── com
+│       │       └── example
 │       │           └── starter
 │       │               └── StarterPlugin.java
 │       └── resources
@@ -49,7 +49,7 @@ description: 了解插件项目的文件结构
 
 `src` 目录中存放的是后端代码，这部分遵循标准的 Java 项目结构。以下是各个文件和文件夹的说明：
 
-- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/run/halo/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
+- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/com/example/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
 - `plugin.yaml`：这是插件的描述文件，位于 `src/main/resources` 目录下。该文件是必须的，包含插件的基本信息，如插件名称、版本、作者、描述以及依赖等内容。
 - `resources/console`：该文件夹通常包含前端部分打包后生成的文件，包括 main.js（JavaScript 文件）和 style.css（样式表）。如果插件不包含前端部分，此目录可以忽略。
 

--- a/versioned_docs/version-2.22/developer-guide/plugin/basics/ui/build.md
+++ b/versioned_docs/version-2.22/developer-guide/plugin/basics/ui/build.md
@@ -288,7 +288,7 @@ export default definePlugin({
         id "run.halo.plugin.devtools" version "0.6.0"
     }
 
-    group 'run.halo.starter'
+    group 'com.example.starter'
 
     repositories {
         mavenCentral()
@@ -342,7 +342,7 @@ export default definePlugin({
         id "com.github.node-gradle.node" version "7.1.0"
     }
 
-    group 'run.halo.starter.ui'
+    group 'com.example.starter.ui'
 
     tasks.register('buildFrontend', PnpmTask) {
         group = 'build'

--- a/versioned_docs/version-2.22/developer-guide/plugin/examples/todolist.md
+++ b/versioned_docs/version-2.22/developer-guide/plugin/examples/todolist.md
@@ -18,7 +18,7 @@ description: 这个例子展示了如何开发 Todo List 插件
 首先创建一个 `class` 名为 `Todo` 并写入如下内容：
 
 ```java
-package run.halo.tutorial;
+package com.example.tutorial;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 

--- a/versioned_docs/version-2.22/developer-guide/plugin/interaction/shared-events.md
+++ b/versioned_docs/version-2.22/developer-guide/plugin/interaction/shared-events.md
@@ -124,7 +124,7 @@ public class CustomEventPublisher {
 
    ```groovy
    dependencies {
-     compileOnly "run.halo.example:plugin-a-api:1.0.0"
+     compileOnly "com.example.app:plugin-a-api:1.0.0"
    }
    ```
 

--- a/versioned_docs/version-2.23/developer-guide/plugin/basics/structure.md
+++ b/versioned_docs/version-2.23/developer-guide/plugin/basics/structure.md
@@ -25,8 +25,8 @@ description: 了解插件项目的文件结构
 ├── src
 │   └── main
 │       ├── java
-│       │   └── run
-│       │       └── halo
+│       │   └── com
+│       │       └── example
 │       │           └── starter
 │       │               └── StarterPlugin.java
 │       └── resources
@@ -49,7 +49,7 @@ description: 了解插件项目的文件结构
 
 `src` 目录中存放的是后端代码，这部分遵循标准的 Java 项目结构。以下是各个文件和文件夹的说明：
 
-- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/run/halo/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
+- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/com/example/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
 - `plugin.yaml`：这是插件的描述文件，位于 `src/main/resources` 目录下。该文件是必须的，包含插件的基本信息，如插件名称、版本、作者、描述以及依赖等内容。
 - `resources/console`：该文件夹通常包含前端部分打包后生成的文件，包括 main.js（JavaScript 文件）和 style.css（样式表）。如果插件不包含前端部分，此目录可以忽略。
 

--- a/versioned_docs/version-2.23/developer-guide/plugin/basics/ui/build.md
+++ b/versioned_docs/version-2.23/developer-guide/plugin/basics/ui/build.md
@@ -288,7 +288,7 @@ export default definePlugin({
         id "run.halo.plugin.devtools" version "0.6.0"
     }
 
-    group 'run.halo.starter'
+    group 'com.example.starter'
 
     repositories {
         mavenCentral()
@@ -342,7 +342,7 @@ export default definePlugin({
         id "com.github.node-gradle.node" version "7.1.0"
     }
 
-    group 'run.halo.starter.ui'
+    group 'com.example.starter.ui'
 
     tasks.register('buildFrontend', PnpmTask) {
         group = 'build'

--- a/versioned_docs/version-2.23/developer-guide/plugin/examples/todolist.md
+++ b/versioned_docs/version-2.23/developer-guide/plugin/examples/todolist.md
@@ -18,7 +18,7 @@ description: 这个例子展示了如何开发 Todo List 插件
 首先创建一个 `class` 名为 `Todo` 并写入如下内容：
 
 ```java
-package run.halo.tutorial;
+package com.example.tutorial;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 

--- a/versioned_docs/version-2.23/developer-guide/plugin/interaction/shared-events.md
+++ b/versioned_docs/version-2.23/developer-guide/plugin/interaction/shared-events.md
@@ -124,7 +124,7 @@ public class CustomEventPublisher {
 
    ```groovy
    dependencies {
-     compileOnly "run.halo.example:plugin-a-api:1.0.0"
+     compileOnly "com.example.app:plugin-a-api:1.0.0"
    }
    ```
 

--- a/versioned_docs/version-2.24/developer-guide/plugin/basics/structure.md
+++ b/versioned_docs/version-2.24/developer-guide/plugin/basics/structure.md
@@ -25,8 +25,8 @@ description: 了解插件项目的文件结构
 ├── src
 │   └── main
 │       ├── java
-│       │   └── run
-│       │       └── halo
+│       │   └── com
+│       │       └── example
 │       │           └── starter
 │       │               └── StarterPlugin.java
 │       └── resources
@@ -49,7 +49,7 @@ description: 了解插件项目的文件结构
 
 `src` 目录中存放的是后端代码，这部分遵循标准的 Java 项目结构。以下是各个文件和文件夹的说明：
 
-- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/run/halo/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
+- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/com/example/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
 - `plugin.yaml`：这是插件的描述文件，位于 `src/main/resources` 目录下。该文件是必须的，包含插件的基本信息，如插件名称、版本、作者、描述以及依赖等内容。
 - `resources/console`：该文件夹通常包含前端部分打包后生成的文件，包括 main.js（JavaScript 文件）和 style.css（样式表）。如果插件不包含前端部分，此目录可以忽略。
 

--- a/versioned_docs/version-2.24/developer-guide/plugin/basics/ui/build.md
+++ b/versioned_docs/version-2.24/developer-guide/plugin/basics/ui/build.md
@@ -288,7 +288,7 @@ export default definePlugin({
         id "run.halo.plugin.devtools" version "0.6.0"
     }
 
-    group 'run.halo.starter'
+    group 'com.example.starter'
 
     repositories {
         mavenCentral()
@@ -342,7 +342,7 @@ export default definePlugin({
         id "com.github.node-gradle.node" version "7.1.0"
     }
 
-    group 'run.halo.starter.ui'
+    group 'com.example.starter.ui'
 
     tasks.register('buildFrontend', PnpmTask) {
         group = 'build'

--- a/versioned_docs/version-2.24/developer-guide/plugin/examples/todolist.md
+++ b/versioned_docs/version-2.24/developer-guide/plugin/examples/todolist.md
@@ -18,7 +18,7 @@ description: 这个例子展示了如何开发 Todo List 插件
 首先创建一个 `class` 名为 `Todo` 并写入如下内容：
 
 ```java
-package run.halo.tutorial;
+package com.example.tutorial;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 

--- a/versioned_docs/version-2.24/developer-guide/plugin/interaction/shared-events.md
+++ b/versioned_docs/version-2.24/developer-guide/plugin/interaction/shared-events.md
@@ -124,7 +124,7 @@ public class CustomEventPublisher {
 
    ```groovy
    dependencies {
-     compileOnly "run.halo.example:plugin-a-api:1.0.0"
+     compileOnly "com.example.app:plugin-a-api:1.0.0"
    }
    ```
 

--- a/versioned_docs/version-2.25/developer-guide/plugin/basics/structure.md
+++ b/versioned_docs/version-2.25/developer-guide/plugin/basics/structure.md
@@ -25,8 +25,8 @@ description: 了解插件项目的文件结构
 ├── src
 │   └── main
 │       ├── java
-│       │   └── run
-│       │       └── halo
+│       │   └── com
+│       │       └── example
 │       │           └── starter
 │       │               └── StarterPlugin.java
 │       └── resources
@@ -49,7 +49,7 @@ description: 了解插件项目的文件结构
 
 `src` 目录中存放的是后端代码，这部分遵循标准的 Java 项目结构。以下是各个文件和文件夹的说明：
 
-- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/run/halo/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
+- `StarterPlugin.java`：插件后端的入口文件，位于 `src/main/java/com/example/starter` 路径下。你可以根据需要修改包名和类名，但需要确保该类继承 `run.halo.app.plugin.BasePlugin`，以指定其为插件的入口。
 - `plugin.yaml`：这是插件的描述文件，位于 `src/main/resources` 目录下。该文件是必须的，包含插件的基本信息，如插件名称、版本、作者、描述以及依赖等内容。
 - `resources/console`：该文件夹通常包含前端部分打包后生成的文件，包括 main.js（JavaScript 文件）和 style.css（样式表）。如果插件不包含前端部分，此目录可以忽略。
 

--- a/versioned_docs/version-2.25/developer-guide/plugin/basics/ui/build.md
+++ b/versioned_docs/version-2.25/developer-guide/plugin/basics/ui/build.md
@@ -288,7 +288,7 @@ export default definePlugin({
         id "run.halo.plugin.devtools" version "0.6.0"
     }
 
-    group 'run.halo.starter'
+    group 'com.example.starter'
 
     repositories {
         mavenCentral()
@@ -342,7 +342,7 @@ export default definePlugin({
         id "com.github.node-gradle.node" version "7.1.0"
     }
 
-    group 'run.halo.starter.ui'
+    group 'com.example.starter.ui'
 
     tasks.register('buildFrontend', PnpmTask) {
         group = 'build'

--- a/versioned_docs/version-2.25/developer-guide/plugin/examples/todolist.md
+++ b/versioned_docs/version-2.25/developer-guide/plugin/examples/todolist.md
@@ -18,7 +18,7 @@ description: 这个例子展示了如何开发 Todo List 插件
 首先创建一个 `class` 名为 `Todo` 并写入如下内容：
 
 ```java
-package run.halo.tutorial;
+package com.example.tutorial;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 

--- a/versioned_docs/version-2.25/developer-guide/plugin/interaction/shared-events.md
+++ b/versioned_docs/version-2.25/developer-guide/plugin/interaction/shared-events.md
@@ -124,7 +124,7 @@ public class CustomEventPublisher {
 
    ```groovy
    dependencies {
-     compileOnly "run.halo.example:plugin-a-api:1.0.0"
+     compileOnly "com.example.app:plugin-a-api:1.0.0"
    }
    ```
 


### PR DESCRIPTION
## Summary

- Replace Halo-owned package paths and Gradle group IDs in plugin examples with `com.example` namespaces.
- Update sample inter-plugin dependency coordinates to avoid suggesting that plugin developers use the `run.halo` namespace.
- Apply the changes to the current documentation and versioned documentation from Halo 2.20 through 2.25.

## Testing

- `pnpm lint`
- `pnpm build`
- `git diff --check`