### PR TITLE
Sync intro pages with Halo README

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -21,6 +21,7 @@ slug: /
 <a href="https://github.com/halo-dev/halo/commits"><img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/halo-dev/halo.svg?style=flat-square" /></a>
 <a href="https://github.com/halo-dev/halo/actions"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/halo-dev/halo/halo.yaml?branch=main&style=flat-square" /></a>
 <a href="https://codecov.io/gh/halo-dev/halo"><img alt="Codecov percentage" src="https://img.shields.io/codecov/c/github/halo-dev/halo/main?style=flat-square&token=YsRUg9fall"/></a>
+<a href="https://gitcode.com/feizhiyun/Halo"><img src="https://gitcode.com/feizhiyun/Halo/star/badge.svg" alt="GitCode Stars" /></a>
 <a href="https://www.producthunt.com/posts/halo-6b401e75-bb58-4dff-9fe9-2ada3323c874?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-halo&#0045;6b401e75&#0045;bb58&#0045;4dff&#0045;9fe9&#0045;2ada3323c874" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=407442&theme=light" alt="Halo - Powerful&#0032;and&#0032;easy&#0045;to&#0045;use&#0032;Open&#0045;Source&#0032;website&#0032;building&#0032;tool | Product Hunt" style={{height: '20px'}} height="20px" /></a>
 </p>
 
@@ -48,11 +49,7 @@ Halo 是一款强大易用的开源建站工具，从个人博客、知识库，
 docker run -d --name halo -p 8090:8090 -v ~/.halo2:/root/.halo2 halohub/halo:2.25
 ```
 
-或者点击下方按钮使用 [Gitpod](https://gitpod.io/) 启动一个体验环境：
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/halo-sigs/gitpod-demo)
-
-以上仅作为体验使用，详细部署文档请查阅：[https://docs.halo.run/getting-started/install/docker-compose](https://docs.halo.run/getting-started/install/docker-compose)
+**以上方式仅作为体验使用，推荐使用开源 Linux 服务器运维管理面板 [1Panel](https://github.com/1Panel-dev/1Panel) 进行部署（[查看文档](https://docs.halo.run/getting-started/install/1panel)），轻松搞定反向代理、SSL 证书及升级备份任务。更多部署方式，请[查看文档](https://docs.halo.run/category/%E5%AE%89%E8%A3%85%E6%8C%87%E5%8D%97)。**
 
 ## 在线体验
 
@@ -85,9 +82,11 @@ docker run -d --name halo -p 8090:8090 -v ~/.halo2:/root/.halo2 halohub/halo:2.2
 
 关于三个版本的详细对比，请参考[版本对比](https://www.lxware.cn/halo)。
 
-## 生态
+## 应用生态
 
-可访问 [官方应用市场](https://www.halo.run/store/apps) 或 [awesome-halo 仓库](https://github.com/halo-sigs/awesome-halo) 查看适用于 Halo 2.x 的主题和插件。
+- **应用市场**：提供丰富的站点主题与功能插件，[立即访问](https://www.halo.run/store/apps)
+- **成为开发者**：支持自主发布并管理应用，[了解详情](https://www.halo.run/archives/halo-app-store-developer-onboarding-app-creation)
+- [halo-sigs/awesome-halo](https://github.com/halo-sigs/awesome-halo)
 
 ## 许可证
 

--- a/versioned_docs/version-2.25/intro.md
+++ b/versioned_docs/version-2.25/intro.md
@@ -21,6 +21,7 @@ slug: /
 <a href="https://github.com/halo-dev/halo/commits"><img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/halo-dev/halo.svg?style=flat-square" /></a>
 <a href="https://github.com/halo-dev/halo/actions"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/halo-dev/halo/halo.yaml?branch=main&style=flat-square" /></a>
 <a href="https://codecov.io/gh/halo-dev/halo"><img alt="Codecov percentage" src="https://img.shields.io/codecov/c/github/halo-dev/halo/main?style=flat-square&token=YsRUg9fall"/></a>
+<a href="https://gitcode.com/feizhiyun/Halo"><img src="https://gitcode.com/feizhiyun/Halo/star/badge.svg" alt="GitCode Stars" /></a>
 <a href="https://www.producthunt.com/posts/halo-6b401e75-bb58-4dff-9fe9-2ada3323c874?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-halo&#0045;6b401e75&#0045;bb58&#0045;4dff&#0045;9fe9&#0045;2ada3323c874" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=407442&theme=light" alt="Halo - Powerful&#0032;and&#0032;easy&#0045;to&#0045;use&#0032;Open&#0045;Source&#0032;website&#0032;building&#0032;tool | Product Hunt" style={{height: '20px'}} height="20px" /></a>
 </p>
 
@@ -48,11 +49,7 @@ Halo 是一款强大易用的开源建站工具，从个人博客、知识库，
 docker run -d --name halo -p 8090:8090 -v ~/.halo2:/root/.halo2 halohub/halo:2.25
 ```
 
-或者点击下方按钮使用 [Gitpod](https://gitpod.io/) 启动一个体验环境：
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/halo-sigs/gitpod-demo)
-
-以上仅作为体验使用，详细部署文档请查阅：[https://docs.halo.run/getting-started/install/docker-compose](https://docs.halo.run/getting-started/install/docker-compose)
+**以上方式仅作为体验使用，推荐使用开源 Linux 服务器运维管理面板 [1Panel](https://github.com/1Panel-dev/1Panel) 进行部署（[查看文档](https://docs.halo.run/getting-started/install/1panel)），轻松搞定反向代理、SSL 证书及升级备份任务。更多部署方式，请[查看文档](https://docs.halo.run/category/%E5%AE%89%E8%A3%85%E6%8C%87%E5%8D%97)。**
 
 ## 在线体验
 
@@ -85,9 +82,11 @@ docker run -d --name halo -p 8090:8090 -v ~/.halo2:/root/.halo2 halohub/halo:2.2
 
 关于三个版本的详细对比，请参考[版本对比](https://www.lxware.cn/halo)。
 
-## 生态
+## 应用生态
 
-可访问 [官方应用市场](https://www.halo.run/store/apps) 或 [awesome-halo 仓库](https://github.com/halo-sigs/awesome-halo) 查看适用于 Halo 2.x 的主题和插件。
+- **应用市场**：提供丰富的站点主题与功能插件，[立即访问](https://www.halo.run/store/apps)
+- **成为开发者**：支持自主发布并管理应用，[了解详情](https://www.halo.run/archives/halo-app-store-developer-onboarding-app-creation)
+- [halo-sigs/awesome-halo](https://github.com/halo-sigs/awesome-halo)
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

- Sync the current and Halo 2.25 introduction pages with the Halo repository README.
- Replace the obsolete Gitpod quick-start entry with the recommended 1Panel deployment guidance.
- Add the GitCode badge and update the application ecosystem links.

## Testing

- `corepack pnpm@10.33.0 lint`
- `corepack pnpm@10.33.0 build`
- `git diff --check`
